### PR TITLE
fix: invalid initializer to pickle

### DIFF
--- a/src/fetch_curriculum_tree.py
+++ b/src/fetch_curriculum_tree.py
@@ -170,7 +170,7 @@ def main():
     curriculum = curriculums[args.curriculum]
 
     try:
-        thread_pool = Pool(args.parallel_drivers, initializer=lambda: prepare_driver(curriculum))
+        thread_pool = Pool(args.parallel_drivers, initializer=prepare_driver, initargs=(curriculum,))
         time.sleep(4)
         [(page1_url, num_pages)] = thread_pool.map(get_page1_url_and_num_pages, [curriculum])
         results = tqdm.tqdm(thread_pool.imap(fetch_curriculum_course_infos,


### PR DESCRIPTION
Fixes `AttributeError: Can't pickle local object 'main.<locals>.<lambda>'` as [`multiprocessing`](https://docs.python.org/3/library/multiprocessing.html) uses [`pickle`](https://docs.python.org/3/library/pickle.html) under the hood which [isn't able to serialize lambdas](https://docs.python.org/3/library/pickle.html#what-can-be-pickled-and-unpickled).

To quote from the pickle docs: "_functions [can be pickled] (built-in and user-defined) accessible from the top level of a module (using [def](https://docs.python.org/3/reference/compound_stmts.html#def), not [lambda](https://docs.python.org/3/reference/expressions.html#lambda))_"